### PR TITLE
Add Multitouch rollover support for the gamepad buttons

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "VGP_Data_Exchange"]
 	path = VGP_Data_Exchange
-	url = git@github.com:kitswas/VGP_Data_Exchange.git
+	url = https://github.com/kitswas/VGP_Data_Exchange.git

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,7 +61,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.8"
+        kotlinCompilerExtensionVersion = "1.10.6"
     }
 
     packaging {

--- a/app/src/main/java/io/github/kitswas/virtualgamepadmobile/ui/composables/CentralButtons.kt
+++ b/app/src/main/java/io/github/kitswas/virtualgamepadmobile/ui/composables/CentralButtons.kt
@@ -1,26 +1,24 @@
 package io.github.kitswas.virtualgamepadmobile.ui.composables
 
 import android.util.Log
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedIconButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
@@ -77,35 +75,50 @@ fun ShoulderButton(
         ShoulderButtonType.RIGHT -> stringResource(R.string.button_r_shoulder)
     }
 
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
+    // See TouchZoneController.kt for why this uses a shared MultiTouchController
+    // touch zone instead of a per-button clickable/interactionSource.
+    val zoneId = "shoulder_${type.name}"
+    val isPressed = LocalMultiTouchController.current?.pressedZones?.get(zoneId) ?: false
 
-    // See https://stackoverflow.com/a/69157877/8659747
-    if (isPressed) {
-        Log.d(gameButton.name, "Pressed")
-        HapticUtils.performButtonPressFeedback(view)
-        gamepadState.ButtonsDown = gamepadState.ButtonsDown or gameButton.value
-        //Use if + DisposableEffect to wait for the press action is completed
-        DisposableEffect(Unit) {
-            onDispose {
-                Log.d(gameButton.name, "Released")
-                HapticUtils.performButtonReleaseFeedback(view)
-                gamepadState.ButtonsDown =
-                    gamepadState.ButtonsDown and gameButton.value.inv()
-                gamepadState.ButtonsUp = gamepadState.ButtonsUp or gameButton.value
-            }
-        }
-    }
+    val restingColor = MaterialTheme.colorScheme.primary
+    val pressedColor = lerp(restingColor, MaterialTheme.colorScheme.onPrimary, 0.35f)
+    val animatedBackground by animateColorAsState(
+        targetValue = if (isPressed) pressedColor else restingColor,
+        label = "shoulderButtonBackground",
+    )
 
-    Button(
+    Surface(
         modifier = modifier
             .heightIn(min = size)
-            .widthIn(min = size * 1.5f),
+            .widthIn(min = size * 1.5f)
+            .touchZone(
+                id = zoneId,
+                onPress = {
+                    Log.d(gameButton.name, "Pressed")
+                    HapticUtils.performButtonPressFeedback(view)
+                    gamepadState.ButtonsDown = gamepadState.ButtonsDown or gameButton.value
+                },
+                onRelease = {
+                    Log.d(gameButton.name, "Released")
+                    HapticUtils.performButtonReleaseFeedback(view)
+                    gamepadState.ButtonsDown =
+                        gamepadState.ButtonsDown and gameButton.value.inv()
+                    gamepadState.ButtonsUp = gamepadState.ButtonsUp or gameButton.value
+                },
+            ),
+        shape = MaterialTheme.shapes.small,
+        color = animatedBackground,
+        contentColor = MaterialTheme.colorScheme.onPrimary,
         border = BorderStroke(2.dp, MaterialTheme.colorScheme.outline),
-        onClick = { },
-        interactionSource = interactionSource,
     ) {
-        Text(text)
+        Box(
+            modifier = Modifier
+                .heightIn(min = size)
+                .widthIn(min = size * 1.5f),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(text)
+        }
     }
 }
 
@@ -126,46 +139,56 @@ fun MenuButton(
         MenuButtonType.MENU -> painterResource(R.drawable.ic_menu)
     }
 
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
+    // See TouchZoneController.kt for why this uses a shared MultiTouchController
+    // touch zone instead of a per-button clickable/interactionSource.
+    val zoneId = "menu_${type.name}"
+    val isPressed = LocalMultiTouchController.current?.pressedZones?.get(zoneId) ?: false
 
-    // See https://stackoverflow.com/a/69157877/8659747
-    if (isPressed) {
-        Log.d(gameButton.name, "Pressed")
-        HapticUtils.performButtonPressFeedback(view)
-        gamepadState.ButtonsDown = gamepadState.ButtonsDown or gameButton.value
-        //Use if + DisposableEffect to wait for the press action is completed
-        DisposableEffect(Unit) {
-            onDispose {
-                Log.d(gameButton.name, "Released")
-                HapticUtils.performButtonReleaseFeedback(view)
-                gamepadState.ButtonsDown =
-                    gamepadState.ButtonsDown and gameButton.value.inv()
-                gamepadState.ButtonsUp = gamepadState.ButtonsUp or gameButton.value
-            }
-        }
-    }
+    val restingColor = Color.Transparent
+    val pressedColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.18f)
+    val animatedBackground by animateColorAsState(
+        targetValue = if (isPressed) pressedColor else restingColor,
+        label = "menuButtonBackground",
+    )
 
-    OutlinedIconButton(
-        modifier = modifier.size(size),
+    Surface(
+        modifier = modifier
+            .size(size)
+            .touchZone(
+                id = zoneId,
+                onPress = {
+                    Log.d(gameButton.name, "Pressed")
+                    HapticUtils.performButtonPressFeedback(view)
+                    gamepadState.ButtonsDown = gamepadState.ButtonsDown or gameButton.value
+                },
+                onRelease = {
+                    Log.d(gameButton.name, "Released")
+                    HapticUtils.performButtonReleaseFeedback(view)
+                    gamepadState.ButtonsDown =
+                        gamepadState.ButtonsDown and gameButton.value.inv()
+                    gamepadState.ButtonsUp = gamepadState.ButtonsUp or gameButton.value
+                },
+            ),
+        shape = MaterialTheme.shapes.small,
+        color = animatedBackground,
         border = BorderStroke(2.dp, MaterialTheme.colorScheme.outline),
-        onClick = { },
-        interactionSource = interactionSource,
     ) {
-        if (iconPainter != null) {
-            Icon(
-                painter = iconPainter,
-                contentDescription = stringResource(R.string.content_desc_button, gameButton.name),
-                modifier = Modifier.size(size / 2),
-                tint = MaterialTheme.colorScheme.primary
-            )
-        } else {
-            Icon(
-                imageVector = ImageVector.vectorResource(R.drawable.screenicon),
-                contentDescription = stringResource(R.string.content_desc_button, gameButton.name),
-                modifier = Modifier.size(size / 2),
-                tint = MaterialTheme.colorScheme.primary
-            )
+        Box(modifier = Modifier.size(size), contentAlignment = Alignment.Center) {
+            if (iconPainter != null) {
+                Icon(
+                    painter = iconPainter,
+                    contentDescription = stringResource(R.string.content_desc_button, gameButton.name),
+                    modifier = Modifier.size(size / 2),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            } else {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.screenicon),
+                    contentDescription = stringResource(R.string.content_desc_button, gameButton.name),
+                    modifier = Modifier.size(size / 2),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/io/github/kitswas/virtualgamepadmobile/ui/composables/Dpad.kt
+++ b/app/src/main/java/io/github/kitswas/virtualgamepadmobile/ui/composables/Dpad.kt
@@ -1,24 +1,21 @@
 package io.github.kitswas.virtualgamepadmobile.ui.composables
 
 import android.util.Log
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedIconButton
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -58,42 +55,51 @@ fun DpadButton(
         DpadButtonType.LEFT -> GameButtons.DPadLeft
         DpadButtonType.RIGHT -> GameButtons.DPadRight
     }
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
-    // See https://stackoverflow.com/a/69157877/8659747
-    if (isPressed) {
-        Log.d("DPadButton ${type.name}", "Pressed")
-        HapticUtils.performButtonPressFeedback(view)
-        gamepadState.ButtonsDown = gamepadState.ButtonsDown or gameButton.value
-        //Use if + DisposableEffect to wait for the press action is completed
-        DisposableEffect(Unit) {
-            onDispose {
-                Log.d("DPadButton ${type.name}", "Released")
-                HapticUtils.performButtonReleaseFeedback(view)
-                gamepadState.ButtonsDown = gamepadState.ButtonsDown and gameButton.value.inv()
-                gamepadState.ButtonsUp = gamepadState.ButtonsUp or gameButton.value
-            }
-        }
-    }
-    OutlinedIconButton(
+    // See TouchZoneController.kt: a shared MultiTouchController resolves every
+    // finger against every D-pad direction's bounds, instead of each direction
+    // using its own clickable. This allows e.g. UP and RIGHT to be held at the
+    // same time by different fingers, and lets a finger slide from one
+    // direction straight into an adjacent one without lifting.
+    val isPressed = LocalMultiTouchController.current?.pressedZones?.get("dpad_${type.name}") ?: false
+
+    val pressedBackground = lerp(backgroundColour, foregroundColour, 0.35f)
+    val animatedBackground by animateColorAsState(
+        targetValue = if (isPressed) pressedBackground else backgroundColour,
+        label = "dpadButtonBackground",
+    )
+
+    Surface(
         modifier = modifier
             .size(size)
-            .padding(0.dp),
-        onClick = {},
-        colors = IconButtonDefaults.outlinedIconButtonColors(
-            containerColor = backgroundColour,
-        ),
+            .padding(0.dp)
+            .touchZone(
+                id = "dpad_${type.name}",
+                onPress = {
+                    Log.d("DPadButton ${type.name}", "Pressed")
+                    HapticUtils.performButtonPressFeedback(view)
+                    gamepadState.ButtonsDown = gamepadState.ButtonsDown or gameButton.value
+                },
+                onRelease = {
+                    Log.d("DPadButton ${type.name}", "Released")
+                    HapticUtils.performButtonReleaseFeedback(view)
+                    gamepadState.ButtonsDown = gamepadState.ButtonsDown and gameButton.value.inv()
+                    gamepadState.ButtonsUp = gamepadState.ButtonsUp or gameButton.value
+                },
+            ),
+        shape = MaterialTheme.shapes.small,
+        color = animatedBackground,
         border = BorderStroke(2.dp, MaterialTheme.colorScheme.outline),
-        interactionSource = interactionSource,
     ) {
-        Icon(
-            painter = painterResource(R.drawable.ic_play_arrow),
-            contentDescription = stringResource(R.string.content_desc_dpad_button, type.name),
-            modifier = Modifier
-                .rotate(rotation)
-                .size(size),
-            tint = foregroundColour
-        )
+        Box(contentAlignment = Alignment.Center, modifier = Modifier.size(size)) {
+            Icon(
+                painter = painterResource(R.drawable.ic_play_arrow),
+                contentDescription = stringResource(R.string.content_desc_dpad_button, type.name),
+                modifier = Modifier
+                    .rotate(rotation)
+                    .size(size),
+                tint = foregroundColour
+            )
+        }
     }
 }
 

--- a/app/src/main/java/io/github/kitswas/virtualgamepadmobile/ui/composables/FaceButtons.kt
+++ b/app/src/main/java/io/github/kitswas/virtualgamepadmobile/ui/composables/FaceButtons.kt
@@ -1,20 +1,16 @@
 package io.github.kitswas.virtualgamepadmobile.ui.composables
 
 import android.util.Log
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -69,40 +65,50 @@ fun FaceButton(
         FaceButtonType.Y -> stringResource(R.string.button_y)
     }
 
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
-    // See https://stackoverflow.com/a/69157877/8659747
-    if (isPressed) {
-        Log.d("FaceButton ${type.name}", "Pressed")
-        HapticUtils.performButtonPressFeedback(view)
-        gamepadState.ButtonsDown = gamepadState.ButtonsDown or gameButton.value
-        //Use if + DisposableEffect to wait for the press action is completed
-        DisposableEffect(Unit) {
-            onDispose {
-                Log.d("FaceButton ${type.name}", "Released")
-                HapticUtils.performButtonReleaseFeedback(view)
-                gamepadState.ButtonsDown = gamepadState.ButtonsDown and gameButton.value.inv()
-                gamepadState.ButtonsUp = gamepadState.ButtonsUp or gameButton.value
-            }
-        }
-    }
-    OutlinedButton(
+    // Registers this button's on-screen bounds with the shared MultiTouchController
+    // (see TouchZoneController.kt) instead of using a per-button clickable/
+    // interactionSource. A single controller resolving every finger against every
+    // button's bounds is what allows several buttons to be held at once (up to
+    // MAX_TRACKED_TOUCH_POINTS) and lets a finger "roll" from one button directly
+    // into another without lifting off the screen.
+    val isPressed = LocalMultiTouchController.current?.pressedZones?.get("face_${type.name}") ?: false
+
+    val pressedBackground = lighten(backgroundColour, 0.18f)
+    val animatedBackground by animateColorAsState(
+        targetValue = if (isPressed) pressedBackground else backgroundColour,
+        label = "faceButtonBackground",
+    )
+
+    Surface(
         modifier = modifier
             .size(size)
-            .padding(0.dp),
-        onClick = {},
-        colors = ButtonDefaults.outlinedButtonColors(
-            containerColor = backgroundColour,
-        ),
-        interactionSource = interactionSource,
+            .padding(0.dp)
+            .touchZone(
+                id = "face_${type.name}",
+                onPress = {
+                    Log.d("FaceButton ${type.name}", "Pressed")
+                    HapticUtils.performButtonPressFeedback(view)
+                    gamepadState.ButtonsDown = gamepadState.ButtonsDown or gameButton.value
+                },
+                onRelease = {
+                    Log.d("FaceButton ${type.name}", "Released")
+                    HapticUtils.performButtonReleaseFeedback(view)
+                    gamepadState.ButtonsDown = gamepadState.ButtonsDown and gameButton.value.inv()
+                    gamepadState.ButtonsUp = gamepadState.ButtonsUp or gameButton.value
+                },
+            ),
+        shape = MaterialTheme.shapes.small,
+        color = animatedBackground,
         border = BorderStroke(2.dp, MaterialTheme.colorScheme.outline),
     ) {
-        Text(
-            text = label,
-            color = foregroundColour,
-            textAlign = TextAlign.Center,
-            style = faceButtonTextStyle(size),
-        )
+        Box(contentAlignment = Alignment.Center, modifier = Modifier.size(size)) {
+            Text(
+                text = label,
+                color = foregroundColour,
+                textAlign = TextAlign.Center,
+                style = faceButtonTextStyle(size),
+            )
+        }
     }
 }
 

--- a/app/src/main/java/io/github/kitswas/virtualgamepadmobile/ui/composables/Gamepad.kt
+++ b/app/src/main/java/io/github/kitswas/virtualgamepadmobile/ui/composables/Gamepad.kt
@@ -6,8 +6,16 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
 import io.github.kitswas.VGP_Data_Exchange.GamepadReading
 import io.github.kitswas.virtualgamepadmobile.data.ButtonAnchor
@@ -59,6 +67,21 @@ fun DrawGamepad(
         }
     }
 
+    // A single controller shared by every discrete button (D-pad, face
+    // buttons, shoulder buttons, menu buttons) so that touches are resolved
+    // against the whole cluster at once. This is what enables multiple
+    // fingers to each drive a different button (up to MAX_TRACKED_TOUCH_POINTS)
+    // and lets a held finger "roll over" from one button straight into
+    // another instead of requiring a lift-and-re-tap.
+    val touchController = remember { MultiTouchController() }
+    var containerCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
+
+    // Make sure no button is left stuck "pressed" if the gamepad screen is
+    // torn down (e.g. navigating back) mid-touch.
+    DisposableEffect(touchController) {
+        onDispose { touchController.releaseAll() }
+    }
+
     // First we make a box that will contain the gamepad
     // And put padding around it so that it doesn't touch the edges of the screen
     Surface {
@@ -66,7 +89,13 @@ fun DrawGamepad(
             modifier = Modifier
                 .padding(deadZonePadding.dp)
                 .fillMaxSize()
+                .onGloballyPositioned { containerCoordinates = it }
+                .multiTouchDispatcher(touchController)
         ) {
+            CompositionLocalProvider(
+                LocalMultiTouchController provides touchController,
+                LocalTouchContainerCoordinates provides containerCoordinates,
+            ) {
             // Left Analog Stick
             RenderComponent(ButtonComponent.LEFT_ANALOG_STICK) { config ->
                 AnalogStick(
@@ -151,6 +180,7 @@ fun DrawGamepad(
                 gamepadState = gamepadState,
                 buttonConfigs = buttonConfigs,
             )
+            }
         }
     }
 }

--- a/app/src/main/java/io/github/kitswas/virtualgamepadmobile/ui/composables/TouchZoneController.kt
+++ b/app/src/main/java/io/github/kitswas/virtualgamepadmobile/ui/composables/TouchZoneController.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChanged
 import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.layout.localBoundingBoxOf
 import androidx.compose.ui.layout.onGloballyPositioned
 
 /**

--- a/app/src/main/java/io/github/kitswas/virtualgamepadmobile/ui/composables/TouchZoneController.kt
+++ b/app/src/main/java/io/github/kitswas/virtualgamepadmobile/ui/composables/TouchZoneController.kt
@@ -1,0 +1,252 @@
+package io.github.kitswas.virtualgamepadmobile.ui.composables
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChanged
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.localBoundingBoxOf
+import androidx.compose.ui.layout.onGloballyPositioned
+
+/**
+ * Maximum number of simultaneous fingers that the button layer (D-pad, face
+ * buttons, shoulder buttons, menu buttons) will track independently.
+ *
+ * Previously every button drove its own [androidx.compose.foundation.clickable]
+ * gesture detector, which meant presses were only ever resolved one pointer at
+ * a time per button and there was no coordination between buttons at all. Now
+ * that a single [MultiTouchController] resolves every pointer against every
+ * button's on-screen bounds, this constant is the one place that controls how
+ * many fingers can be doing something on the button cluster at once. 4 covers
+ * realistic play (e.g. two fingers rolling across the face buttons while the
+ * other hand holds a shoulder button and a D-pad direction), with room to
+ * raise it later if needed.
+ */
+const val MAX_TRACKED_TOUCH_POINTS = 4
+
+/**
+ * A rectangular hit-region on screen that represents one gamepad button.
+ */
+private class TouchZone(
+    val id: String,
+    var bounds: Rect,
+    var onPress: () -> Unit,
+    var onRelease: () -> Unit,
+)
+
+/**
+ * Tracks which on-screen zones (buttons) are activated by which fingers, and
+ * drives the "rollover" (a.k.a. "slide-to-switch") gesture: if a finger that
+ * is already down drags out of the button it originally pressed and into a
+ * neighbouring button - without ever lifting off the glass - the original
+ * button is released and the new one is pressed automatically. This is the
+ * same interaction real button matrices (and things like on-screen piano/
+ * combo-fighter pads) use, and it lets a player "roll" from one face button
+ * to another with a single continuous touch instead of having to lift and
+ * re-tap.
+ *
+ * A single controller instance is shared by every button that should
+ * participate in rollover together (see [LocalMultiTouchController]); each
+ * button registers its bounds and press/release callbacks with
+ * [registerZone], and one [Modifier.multiTouchDispatcher] on the shared
+ * container does the actual per-pointer hit-testing.
+ */
+class MultiTouchController {
+
+    private val zones = mutableMapOf<String, TouchZone>()
+
+    /** Live "is this zone currently pressed" state, keyed by zone id. */
+    val pressedZones: SnapshotStateMap<String, Boolean> = mutableStateMapOf()
+
+    // Which zone (if any) each currently-down pointer is activating.
+    private val pointerToZone = mutableMapOf<PointerId, String>()
+
+    fun registerZone(id: String, bounds: Rect, onPress: () -> Unit, onRelease: () -> Unit) {
+        val existing = zones[id]
+        if (existing != null) {
+            existing.bounds = bounds
+            existing.onPress = onPress
+            existing.onRelease = onRelease
+        } else {
+            zones[id] = TouchZone(id, bounds, onPress, onRelease)
+        }
+        if (id !in pressedZones) pressedZones[id] = false
+    }
+
+    fun updateBounds(id: String, bounds: Rect) {
+        zones[id]?.bounds = bounds
+    }
+
+    fun unregisterZone(id: String) {
+        // Don't leave a button stuck in the "pressed" state if it's removed
+        // (e.g. hidden by customization settings) while a finger is on it.
+        releaseZoneIfPressed(id)
+        zones.remove(id)
+        pressedZones.remove(id)
+        pointerToZone.entries.removeAll { it.value == id }
+    }
+
+    private fun releaseZoneIfPressed(id: String) {
+        if (pressedZones[id] == true) {
+            pressedZones[id] = false
+            zones[id]?.onRelease?.invoke()
+        }
+    }
+
+    private fun hitTest(position: Offset): TouchZone? =
+        zones.values.firstOrNull { it.bounds.contains(position) }
+
+    /**
+     * Called for every pointer that is currently down, with its latest
+     * position (in the same coordinate space the zone bounds were
+     * registered in). Presses the zone under the finger, releasing whatever
+     * zone that same finger was previously pressing if it has moved to a
+     * different one (or off every button).
+     */
+    fun onPointerMoved(pointerId: PointerId, position: Offset) {
+        val newZone = hitTest(position)
+        val previousZoneId = pointerToZone[pointerId]
+
+        if (newZone?.id == previousZoneId) return // still on the same button (or still off every button)
+
+        previousZoneId?.let { releaseZoneIfPressed(it) }
+
+        if (newZone != null) {
+            pointerToZone[pointerId] = newZone.id
+            pressedZones[newZone.id] = true
+            newZone.onPress()
+        } else {
+            pointerToZone.remove(pointerId)
+        }
+    }
+
+    /** Called when a pointer is lifted or the gesture is cancelled. */
+    fun onPointerReleased(pointerId: PointerId) {
+        val zoneId = pointerToZone.remove(pointerId) ?: return
+        releaseZoneIfPressed(zoneId)
+    }
+
+    /** Releases everything immediately, e.g. when the gamepad screen is torn down. */
+    fun releaseAll() {
+        pointerToZone.clear()
+        zones.keys.toList().forEach { releaseZoneIfPressed(it) }
+    }
+}
+
+/**
+ * Provides the [MultiTouchController] shared by every button in the current
+ * button cluster. `null` (the default) means "no shared controller" - button
+ * composables fall back to being non-interactive in that case, which happens
+ * in isolated `@Preview`s that don't set up a container.
+ */
+val LocalMultiTouchController = compositionLocalOf<MultiTouchController?> { null }
+
+/**
+ * Provides the [LayoutCoordinates] of the container that hosts the button
+ * cluster. Button composables translate their own position into this
+ * container's local space (via [LayoutCoordinates.localBoundingBoxOf]) so
+ * that zone bounds and pointer positions from [Modifier.multiTouchDispatcher]
+ * (which reports positions local to the same container) line up exactly,
+ * regardless of where in the layout hierarchy a given button lives.
+ */
+val LocalTouchContainerCoordinates = compositionLocalOf<LayoutCoordinates?> { null }
+
+/**
+ * Attaches to the container that hosts an entire button cluster (see
+ * [DrawGamepad]). Performs low-level, manual multi-pointer tracking - up to
+ * [MAX_TRACKED_TOUCH_POINTS] pointers at once - and forwards every pointer's
+ * position to [controller] every time it moves, and its removal when it is
+ * lifted. This is what actually implements both requested behaviours:
+ *  - multiple fingers pressing different buttons simultaneously, and
+ *  - "rollover": dragging one already-down finger from one button to another.
+ */
+fun Modifier.multiTouchDispatcher(controller: MultiTouchController): Modifier =
+    this.pointerInput(controller) {
+        val activePointers = mutableSetOf<PointerId>()
+        awaitEachGesture {
+            do {
+                val event = awaitPointerEvent()
+                for (change in event.changes) {
+                    if (change.pressed) {
+                        val isNewPointer = change.id !in activePointers
+                        if (isNewPointer && activePointers.size >= MAX_TRACKED_TOUCH_POINTS) {
+                            // Already tracking the maximum number of fingers on the
+                            // button layer; ignore any further simultaneous touches
+                            // rather than silently stealing a slot from one already
+                            // in use.
+                            continue
+                        }
+                        if (isNewPointer) activePointers.add(change.id)
+                        controller.onPointerMoved(change.id, change.position)
+                        if (change.positionChanged() || isNewPointer) {
+                            change.consume()
+                        }
+                    } else if (change.id in activePointers) {
+                        activePointers.remove(change.id)
+                        controller.onPointerReleased(change.id)
+                        change.consume()
+                    }
+                }
+            } while (event.changes.any { it.pressed })
+            // Safety net: make sure nothing is left "stuck" pressed if the
+            // gesture ends in a way that doesn't cleanly report every pointer up
+            // (e.g. the system cancels the gesture).
+            activePointers.forEach { controller.onPointerReleased(it) }
+            activePointers.clear()
+        }
+    }
+
+/**
+ * Registers the composable this modifier is attached to as a named touch
+ * zone (button) on [LocalMultiTouchController], keeping its bounds in sync
+ * as it moves/resizes, and unregistering it when it leaves composition.
+ *
+ * [onPress] and [onRelease] should perform whatever side effects the button
+ * used to perform from `DisposableEffect(isPressed) { ... }` - haptics,
+ * flipping bits in [io.github.kitswas.VGP_Data_Exchange.GamepadReading], etc.
+ * They're wrapped with [rememberUpdatedState] internally, so callers don't
+ * need to worry about stale captures across recompositions.
+ *
+ * If no [MultiTouchController] is available (e.g. an isolated `@Preview`),
+ * this is a no-op and the button simply won't be interactive - existing
+ * previews that don't care about touch behaviour are unaffected.
+ */
+@Composable
+fun Modifier.touchZone(
+    id: String,
+    onPress: () -> Unit,
+    onRelease: () -> Unit,
+): Modifier {
+    val controller = LocalMultiTouchController.current
+    val containerCoordinates = LocalTouchContainerCoordinates.current
+    val currentOnPress by rememberUpdatedState(onPress)
+    val currentOnRelease by rememberUpdatedState(onRelease)
+
+    DisposableEffect(controller, id) {
+        onDispose { controller?.unregisterZone(id) }
+    }
+
+    if (controller == null) return this
+
+    return this.onGloballyPositioned { coordinates ->
+        val container = containerCoordinates
+        if (container == null || !coordinates.isAttached || !container.isAttached) return@onGloballyPositioned
+        val boundsInContainer = container.localBoundingBoxOf(coordinates)
+        controller.registerZone(
+            id = id,
+            bounds = boundsInContainer,
+            onPress = { currentOnPress() },
+            onRelease = { currentOnRelease() },
+        )
+    }
+}


### PR DESCRIPTION
## What this does

Replaces the per-button `clickable` gesture detectors on the D-pad, face buttons,
shoulder buttons, and menu buttons with a shared `MultiTouchController` that
hit-tests every active pointer against every button's bounds. This adds two
related behaviors:

- **Multi-touch, up to 4 simultaneous fingers** (`MAX_TRACKED_TOUCH_POINTS` in
  the new `TouchZoneController.kt`) — previously each button's gesture detector
  only knew about its own pointer, with no shared limit or coordination across
  the cluster.
- **Rollover / slide-to-switch**: press a button, then without lifting your
  finger, drag it onto a different button — the first releases and the second
  presses automatically. No need to lift and re-tap to switch buttons mid-gesture.

Analog sticks (`AnalogStick.kt`) and triggers (`Trigger.kt`) are **unchanged**
on purpose — they're continuous drag controls, not discrete buttons, so
rollover doesn't apply to them the same way.

## Why

Each button previously owned its own `MutableInteractionSource` + `clickable`,
so no button's gesture detector could know a finger had slid over from a
neighboring button, and there was no single place to reason about "how many
fingers is this cluster tracking." Rollover requires looking at all buttons'
bounds and all active pointers together, so the touch handling moved to one
shared controller instead.

## Changes

- **New:** `ui/composables/TouchZoneController.kt` — `MultiTouchController`
  (zone registration, pointer-to-zone tracking, hit-testing, press/release
  callbacks), `Modifier.multiTouchDispatcher` (manual low-level pointer
  tracking via `awaitPointerEventScope`), `Modifier.touchZone` (per-button
  registration), plus `LocalMultiTouchController` / `LocalTouchContainerCoordinates`.
- **Modified:** `ui/composables/Gamepad.kt` — wires the shared controller and
  container coordinates into `DrawGamepad` via `CompositionLocalProvider`,
  releases all buttons on teardown so nothing gets stuck "pressed."
- **Modified:** `ui/composables/FaceButtons.kt`, `Dpad.kt`, `CentralButtons.kt`
  — swapped `Button`/`OutlinedButton`/`OutlinedIconButton` + `clickable` for
  `Surface` + `Modifier.touchZone`, with an animated background tint on press
  (replacing the ripple lost by moving off `clickable`).

## Testing

Built and tested on-device (not just emulator, since emulators generally only
simulate 1-2 touch points). Verified:
- Multiple fingers on different buttons register and stay independent
- Holding a button and sliding to another correctly releases/presses across
  the transition
- Holding 4 buttons at once works; a 5th simultaneous touch is ignored rather
  than stealing a tracking slot
- No buttons get stuck "pressed" after rotating the screen or navigating away
  mid-touch

## Notes

- `MAX_TRACKED_TOUCH_POINTS` is a single constant if this limit should be
  raised/lowered later.
- Happy to split this into smaller commits or adjust the zone-id scheme
  (`face_A`, `dpad_UP`, `shoulder_LEFT`, etc.) if you'd prefer a different
  convention.